### PR TITLE
Add Mosek to SDP solver check in sosprogram.

### DIFF
--- a/sosprogram.m
+++ b/sosprogram.m
@@ -47,7 +47,7 @@ function sos = sosprogram(vartable,decvartable)
 % 02/21/02 - SP -- Symbolic polynomial
 % 10/10/02 - SP -- Path checking 
 
-if ~exist('sedumi') & ~exist('sqlp') & ~exist('csdp') & ~exist('sdpnal') & ~exist('sdpnalplus')&  ~exist('sdpam') &  ~exist('cdcs')
+if ~exist('sedumi') & ~exist('sqlp') & ~exist('csdp') & ~exist('sdpnal') & ~exist('sdpnalplus')&  ~exist('sdpam') &  ~exist('cdcs') & ~exist('mosekopt')
     error('No SDP solvers found.') ;
 end;
 


### PR DESCRIPTION
Since version v4.0.0 officially supports Mosek, I believe the check for installed SDP solvers should include this as well.