### PR TITLE
Fix concatenation when first two entries are not dpvar objects.

### DIFF
--- a/dpvar/@dpvar/common_basis.m
+++ b/dpvar/@dpvar/common_basis.m
@@ -33,6 +33,14 @@ function [Enew, Fnew] = common_basis(E,F)
 %
 % Initial coding DJ, MP, SS - 07/07/2021
 
+% Check that the inputs have the correct types.
+if ~isa(E, 'dpvar')
+    error('E must be a dpvar but instead was a %s', class(E))
+end
+if ~isa(F, 'dpvar')
+    error('F must be a dpvar but instead was a %s', class(F))
+end
+
 
 % Check the density of the coefficient matrices
 dnstyE = nnz(E.C)/(size(E.C,1)*size(E.C,2));

--- a/dpvar/@dpvar/common_basis.m
+++ b/dpvar/@dpvar/common_basis.m
@@ -1,6 +1,6 @@
 function [Enew, Fnew] = common_basis(E,F)
-% [Enew,Fnew] = DPcommon_basis(E,F) extends the coeffs of E and F to have
-% same left and right bases
+% [Enew,Fnew] = common_basis(E,F) extends the coeffs of E and F to have
+% same left and right bases.
 % 
 % INPUTS:
 % E,F : dpvar class objects
@@ -34,11 +34,8 @@ function [Enew, Fnew] = common_basis(E,F)
 % Initial coding DJ, MP, SS - 07/07/2021
 
 % Check that the inputs have the correct types.
-if ~isa(E, 'dpvar')
-    error('E must be a dpvar but instead was a %s', class(E))
-end
-if ~isa(F, 'dpvar')
-    error('F must be a dpvar but instead was a %s', class(F))
+if ~isa(E, 'dpvar') || ~isa(F,'dpvar')
+    error('Both input arguments must be of type ''dpvar''.')
 end
 
 

--- a/dpvar/@dpvar/horzcat.m
+++ b/dpvar/@dpvar/horzcat.m
@@ -55,16 +55,22 @@ else
         error('Objects being concatenated horizontally have different numbers of rows');
     end
     
-    % If input is not a dpvar, convert to dpvar object
+
+    % If first input is not a dpvar, convert to dpvar object.
     if isa(E,'double')
         E = dpvar(E,zeros(1,0),{},{},size(E));
-    elseif isa(F,'double')
-        F = dpvar(F,zeros(1,0),{},{},size(F));
     elseif isa(E,'polynomial')
         E = poly2dpvar(E);
+    elseif ~isa(E,'dpvar')
+        error('Concatenation is only supported for objects of type double, polynomial, or dpvar');
+    end
+        
+    % If second input is not a dpvar, convert to dpvar object.
+    if isa(F,'double')
+        F = dpvar(F,zeros(1,0),{},{},size(F));
     elseif isa(F,'polynomial')
         F = poly2dpvar(F);
-    elseif ~isa(E,'dpvar') || ~isa(F,'dpvar')
+    elseif ~isa(F,'dpvar')
         error('Concatenation is only supported for objects of type double, polynomial, or dpvar');
     end
     

--- a/dpvar/@dpvar/vertcat.m
+++ b/dpvar/@dpvar/vertcat.m
@@ -55,16 +55,21 @@ else
         error('Objects being concatenated vertically have different numbers of columns');
     end
     
-    % If input is not a dpvar, convert to dpvar object
+    % If first input is not a dpvar, convert to dpvar object.
     if isa(E,'double')
         E = dpvar(E,zeros(1,0),{},{},size(E));
-    elseif isa(F,'double')
-        F = dpvar(F,zeros(1,0),{},{},size(F));
     elseif isa(E,'polynomial')
         E = poly2dpvar(E);
+    elseif ~isa(E,'dpvar')
+        error('Concatenation is only supported for objects of type double, polynomial, or dpvar');
+    end
+        
+    % If second input is not a dpvar, convert to dpvar object.
+    if isa(F,'double')
+        F = dpvar(F,zeros(1,0),{},{},size(F));
     elseif isa(F,'polynomial')
         F = poly2dpvar(F);
-    elseif ~isa(E,'dpvar') || ~isa(F,'dpvar')
+    elseif ~isa(F,'dpvar')
         error('Concatenation is only supported for objects of type double, polynomial, or dpvar');
     end
     


### PR DESCRIPTION
Before this fix, the following code causes an error because the concatenation functions will only translate one entry or the other into a dpvar, but not both:
```
dpvar p
f = [1; 1; mydpvar];
```

```
dpvar p
f = [1; 1; mydpvar];
```