### PR TITLE
Removing initial and final comma to allow for multi-objective optimization

### DIFF
--- a/sossetobj.m
+++ b/sossetobj.m
@@ -60,6 +60,15 @@ if isfield(sos,'symvartable')
         objvartable = [objvartable, char(objvartable_temp(i)),','];
     end
 
+    % Remove the first and last comma
+    if startsWith(objvartable, ',')
+        objvartable = objvartable(2:end);
+    end
+
+    if endsWith(objvartable, ',')
+        objvartable = objvartable(1:end-1);
+    end
+
 	objvartable = objvartable(find(objvartable~=' '));        % 03/25/02
   	chardecvartable = sym2chartable(sos.decvartable); %AP 30092020
    	decvartable = [',',chardecvartable,','];


### PR DESCRIPTION
The initial and final comma in the objvartable of sossetobj.m causes issues. To allow for multi-objective optimization, remove these commas. 